### PR TITLE
Add built-in packs: gradle, android, kotlin-multiplatform, ios-xcode

### DIFF
--- a/hazmat/packs/android.yaml
+++ b/hazmat/packs/android.yaml
@@ -1,0 +1,23 @@
+pack:
+  name: android
+  version: 1
+  description: Android SDK project
+
+detect:
+  files: [local.properties]
+
+session:
+  read_dirs:
+    - ~/Library/Android/sdk
+  env_passthrough: [JAVA_HOME]
+
+backup:
+  excludes:
+    - "*.apk"
+    - "*.aab"
+    - "*.aar"
+    - .cxx/
+    - build/
+
+warnings:
+  - "Android SDK is read-only from ~/Library/Android/sdk. Run 'sdkmanager' outside the sandbox to install new SDK components."

--- a/hazmat/packs/gradle.yaml
+++ b/hazmat/packs/gradle.yaml
@@ -1,0 +1,28 @@
+pack:
+  name: gradle
+  version: 1
+  description: Gradle build system (Java/Kotlin/Android)
+
+detect:
+  files: [gradlew]
+
+session:
+  read_dirs:
+    - /opt/homebrew/opt/openjdk
+    - /Library/Java/JavaVirtualMachines
+  env_passthrough: [JAVA_HOME]
+
+backup:
+  excludes:
+    - .gradle/
+    - build/
+    - "*.class"
+    - "*.jar"
+
+warnings:
+  - "Gradle user home (~/.gradle) is not shared into the sandbox. Run './gradlew dependencies' outside to pre-populate the cache for offline builds."
+
+commands:
+  build: ./gradlew assemble
+  test: ./gradlew test
+  check: ./gradlew check

--- a/hazmat/packs/ios-xcode.yaml
+++ b/hazmat/packs/ios-xcode.yaml
@@ -1,0 +1,15 @@
+pack:
+  name: ios-xcode
+  version: 1
+  description: iOS / macOS Xcode project
+
+detect:
+  files: [Podfile, Package.swift]
+
+backup:
+  excludes:
+    - Pods/
+    - DerivedData/
+    - "*.xcarchive"
+    - .build/
+    - "*.ipa"

--- a/hazmat/packs/kotlin-multiplatform.yaml
+++ b/hazmat/packs/kotlin-multiplatform.yaml
@@ -1,0 +1,24 @@
+pack:
+  name: kotlin-multiplatform
+  version: 1
+  description: Kotlin Multiplatform (KMP/KMM) project
+
+detect:
+  files: [settings.gradle.kts]
+
+session:
+  read_dirs:
+    - ~/.konan
+  env_passthrough: [JAVA_HOME]
+
+backup:
+  excludes:
+    - .kotlin/
+    - "*.klib"
+    - xcuserdata/
+    - DerivedData/
+    - build/
+    - .gradle/
+
+warnings:
+  - "Kotlin/Native toolchain (~/.konan) is read-only. Run './gradlew :shared:compileKotlinIosArm64' outside to pre-download the toolchain."


### PR DESCRIPTION
## Summary

- **gradle** — detects `gradlew`; reads Homebrew and system JVM dirs; warns that `~/.gradle` isn't shared (user must pre-populate cache outside the sandbox before use)
- **android** — detects `local.properties`; reads `~/Library/Android/sdk`; excludes build artifacts (`*.apk`, `*.aab`, `*.aar`, `.cxx/`)
- **kotlin-multiplatform** — detects `settings.gradle.kts`; reads `~/.konan` for the Kotlin/Native toolchain; excludes `.kotlin/`, `*.klib`, Xcode noise (`xcuserdata/`, `DerivedData/`)
- **ios-xcode** — detects `Podfile` or `Package.swift`; no extra `read_dirs` (Xcode.app is world-readable); excludes `Pods/`, `DerivedData/`, `*.xcarchive`, `*.ipa`

`ios-xcode` is intended for standalone iOS/macOS apps. KMP repos should use `kotlin-multiplatform`; that's reflected in V3SP3R's `.hazmat/packs.yaml` which lists `gradle`, `android`, and `kotlin-multiplatform` but not `ios-xcode` (the `iosApp/` xcodeproj isn't at the repo root).

## Test plan

- [x] `TestBuiltinPacksLoad` passes (all four packs load without error)
- [x] `TestBuiltinPacksSchemaValid` passes (names, version, env keys, excludes all valid)
- [ ] Manual: `hazmat pack list` shows all four new packs
- [ ] Manual: `hazmat pack show gradle` / `android` / `kotlin-multiplatform` / `ios-xcode` display correct details
- [ ] Manual: launch a hazmat session in a Gradle project with `--pack gradle` and verify JVM read-dir and JAVA_HOME passthrough work