### PR TITLE
Fix shell permission denied on fresh installs

### DIFF
--- a/hazmat/git_safe_directory.go
+++ b/hazmat/git_safe_directory.go
@@ -175,6 +175,12 @@ func plannedProjectGitSafeDirectory(projectDir string) string {
 	return repoDir
 }
 
+func appendAgentGlobalSafeDirectoryCommand(repoDir string) *exec.Cmd {
+	cmd := exec.Command("sudo", "-u", agentUser, "-H", "git", "config", "--global", "--add", "safe.directory", repoDir)
+	cmd.Dir = "/"
+	return cmd
+}
+
 func appendAgentGlobalSafeDirectoryEntryImpl(repoDir string) error {
 	repoDir = normalizeSafeDirectoryEntry(repoDir)
 	if repoDir == "" {
@@ -185,8 +191,7 @@ func appendAgentGlobalSafeDirectoryEntryImpl(repoDir string) error {
 	// This sudo call is covered by the NOPASSWD rule (runs after init).
 	// Use / as cwd so git doesn't fail when the host's cwd is inaccessible
 	// to the agent user (the traverse ACL may not have been applied yet).
-	cmd := exec.Command("sudo", "-u", agentUser, "-H", "git", "config", "--global", "--add", "safe.directory", repoDir)
-	cmd.Dir = "/"
+	cmd := appendAgentGlobalSafeDirectoryCommand(repoDir)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))

--- a/hazmat/git_safe_directory.go
+++ b/hazmat/git_safe_directory.go
@@ -183,7 +183,10 @@ func appendAgentGlobalSafeDirectoryEntryImpl(repoDir string) error {
 	// Write via sudo -u agent because git config needs to create a lock file
 	// in the agent's home directory, which is only writable by agent.
 	// This sudo call is covered by the NOPASSWD rule (runs after init).
+	// Use / as cwd so git doesn't fail when the host's cwd is inaccessible
+	// to the agent user (the traverse ACL may not have been applied yet).
 	cmd := exec.Command("sudo", "-u", agentUser, "-H", "git", "config", "--global", "--add", "safe.directory", repoDir)
+	cmd.Dir = "/"
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))

--- a/hazmat/git_safe_directory_test.go
+++ b/hazmat/git_safe_directory_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -174,5 +175,31 @@ func TestEnsureAgentGitSafeDirectoryAddsExactRepoTrust(t *testing.T) {
 	}
 	if len(agentEntries) != 1 || agentEntries[0] != repoDir {
 		t.Fatalf("agentEntries = %v, want [%q]", agentEntries, repoDir)
+	}
+}
+
+func TestAppendAgentGlobalSafeDirectoryCommandUsesRootWorkingDir(t *testing.T) {
+	repoDir := "/Users/dr/workspace/stack-matrix/pydantic-ai"
+
+	cmd := appendAgentGlobalSafeDirectoryCommand(repoDir)
+
+	if cmd.Dir != "/" {
+		t.Fatalf("appendAgentGlobalSafeDirectoryCommand().Dir = %q, want %q", cmd.Dir, "/")
+	}
+
+	wantArgs := []string{
+		"sudo",
+		"-u",
+		agentUser,
+		"-H",
+		"git",
+		"config",
+		"--global",
+		"--add",
+		"safe.directory",
+		repoDir,
+	}
+	if !reflect.DeepEqual(cmd.Args, wantArgs) {
+		t.Fatalf("appendAgentGlobalSafeDirectoryCommand().Args = %v, want %v", cmd.Args, wantArgs)
 	}
 }

--- a/hazmat/session_mutation.go
+++ b/hazmat/session_mutation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const sessionMutationProofScopeTLAModel = "TLA+ model + tests/docs"
@@ -87,6 +88,11 @@ func buildNativeSessionMutationPlan(cfg sessionConfig) sessionMutationPlan {
 	}
 
 	exposedDirs := append(append([]string{}, cfg.ReadDirs...), cfg.WriteDirs...)
+	// Include project dir's parent so the full path from home to the project
+	// is traversable — not just paths to extra read/write dirs.
+	if parent := filepath.Dir(cfg.ProjectDir); parent != cfg.ProjectDir {
+		exposedDirs = append(exposedDirs, parent)
+	}
 	if pending := pendingAgentTraverseTargets(cfg.ProjectDir, exposedDirs); len(pending) > 0 {
 		projectDir := cfg.ProjectDir
 		pendingCount := len(pending)

--- a/hazmat/workspace_acl.go
+++ b/hazmat/workspace_acl.go
@@ -234,6 +234,15 @@ func pendingAgentTraverseTargets(projectDir string, dirs []string) []string {
 	}
 
 	var pending []string
+
+	// Safety net: ensure home directory itself is still traversable.
+	// init sets this ACL, but permissions can change (macOS updates,
+	// privacy settings, manual chmod). Without home traversal the
+	// agent cannot reach any project directory.
+	if !homeAllowsAgentTraverse(homeDir) {
+		pending = append(pending, homeDir)
+	}
+
 	for _, path := range collectAgentTraverseTargets(homeDir, projectDir, dirs) {
 		if homeAllowsAgentTraverse(path) {
 			continue

--- a/hazmat/workspace_acl.go
+++ b/hazmat/workspace_acl.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+var currentUserHomeDir = os.UserHomeDir
+var pathAllowsAgentTraverse = homeAllowsAgentTraverse
+
 // devGroupACLEntry returns the macOS ACL entry string that grants the dev
 // group full collaborative access with file and directory inheritance.
 func devGroupACLEntry() string {
@@ -228,7 +231,7 @@ func ensureAgentCanTraverseExposedDirs(projectDir string, dirs []string) (bool, 
 }
 
 func pendingAgentTraverseTargets(projectDir string, dirs []string) []string {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := currentUserHomeDir()
 	if err != nil {
 		return nil
 	}
@@ -239,12 +242,12 @@ func pendingAgentTraverseTargets(projectDir string, dirs []string) []string {
 	// init sets this ACL, but permissions can change (macOS updates,
 	// privacy settings, manual chmod). Without home traversal the
 	// agent cannot reach any project directory.
-	if !homeAllowsAgentTraverse(homeDir) {
+	if !pathAllowsAgentTraverse(homeDir) {
 		pending = append(pending, homeDir)
 	}
 
 	for _, path := range collectAgentTraverseTargets(homeDir, projectDir, dirs) {
-		if homeAllowsAgentTraverse(path) {
+		if pathAllowsAgentTraverse(path) {
 			continue
 		}
 		pending = append(pending, path)

--- a/hazmat/workspace_acl_test.go
+++ b/hazmat/workspace_acl_test.go
@@ -274,3 +274,37 @@ func TestCollectAgentTraverseTargetsDeeplyNested(t *testing.T) {
 		}
 	}
 }
+
+func TestPendingAgentTraverseTargetsIncludesHomeSafetyNet(t *testing.T) {
+	savedUserHomeDir := currentUserHomeDir
+	savedPathAllows := pathAllowsAgentTraverse
+	t.Cleanup(func() {
+		currentUserHomeDir = savedUserHomeDir
+		pathAllowsAgentTraverse = savedPathAllows
+	})
+
+	homeDir := filepath.Join(string(os.PathSeparator), "Users", "rv")
+	projectDir := filepath.Join(homeDir, "workspace", "test-hz")
+	parentDir := filepath.Dir(projectDir)
+
+	currentUserHomeDir = func() (string, error) {
+		return homeDir, nil
+	}
+	pathAllowsAgentTraverse = func(path string) bool {
+		return false
+	}
+
+	got := pendingAgentTraverseTargets(projectDir, []string{parentDir})
+	want := []string{
+		homeDir,
+		parentDir,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("pendingAgentTraverseTargets() count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, path := range want {
+		if got[i] != path {
+			t.Fatalf("pendingAgentTraverseTargets()[%d] = %q, want %q (all=%v)", i, got[i], path, got)
+		}
+	}
+}

--- a/hazmat/workspace_acl_test.go
+++ b/hazmat/workspace_acl_test.go
@@ -227,3 +227,50 @@ func TestCollectAgentTraverseTargets(t *testing.T) {
 		}
 	}
 }
+
+func TestCollectAgentTraverseTargetsIncludesProjectParent(t *testing.T) {
+	t.Parallel()
+
+	homeDir := filepath.Join(string(os.PathSeparator), "Users", "rv")
+	projectDir := filepath.Join(homeDir, "workspace", "test-hz")
+
+	// Simulate what buildNativeSessionMutationPlan does: add filepath.Dir(projectDir)
+	parentDir := filepath.Dir(projectDir)
+	got := collectAgentTraverseTargets(homeDir, projectDir, []string{parentDir})
+
+	want := []string{
+		filepath.Join(homeDir, "workspace"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("collectAgentTraverseTargets() with project parent: count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, path := range want {
+		if got[i] != path {
+			t.Fatalf("collectAgentTraverseTargets()[%d] = %q, want %q (all=%v)", i, got[i], path, got)
+		}
+	}
+}
+
+func TestCollectAgentTraverseTargetsDeeplyNested(t *testing.T) {
+	t.Parallel()
+
+	homeDir := filepath.Join(string(os.PathSeparator), "Users", "rv")
+	projectDir := filepath.Join(homeDir, "code", "work", "api", "myproject")
+
+	parentDir := filepath.Dir(projectDir)
+	got := collectAgentTraverseTargets(homeDir, projectDir, []string{parentDir})
+
+	want := []string{
+		filepath.Join(homeDir, "code"),
+		filepath.Join(homeDir, "code", "work"),
+		filepath.Join(homeDir, "code", "work", "api"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("collectAgentTraverseTargets() deeply nested: count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, path := range want {
+		if got[i] != path {
+			t.Fatalf("collectAgentTraverseTargets()[%d] = %q, want %q (all=%v)", i, got[i], path, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3

## Summary

- **Traverse ACL gap**: session mutation plan now includes the project directory's parent chain (not just extra `-R`/`-W` dirs) so intermediate directories like `~/workspace/` get traverse ACLs at session start
- **Home directory safety net**: `pendingAgentTraverseTargets` now checks if the home directory itself is still traversable — if the init-time ACL was lost (macOS update, privacy settings), the session mutation re-applies it
- **Git safe.directory cwd fix**: `sudo -u agent git config` now runs with `/` as cwd instead of inheriting the host's cwd, which the agent can't traverse to before ACLs are applied

## Test plan

- [x] Existing tests pass
- [x] New unit tests for `collectAgentTraverseTargets` with project parent dirs (shallow and deeply nested)
- [ ] @rvolz: install from this branch and test `hazmat shell` in your project directory:
  ```bash
  brew install dredozubov/tap/hazmat --HEAD  # or build from source:
  git checkout fix/shell-permission-denied
  cd hazmat && make all
  ```