### PR TITLE
bootstrap: bump claude installer SHA-256 pin to current install.sh

### DIFF
--- a/hazmat/bootstrap.go
+++ b/hazmat/bootstrap.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	claudeInstallerURL    = "https://claude.ai/install.sh"
-	claudeInstallerSHA256 = "b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830"
+	claudeInstallerSHA256 = "005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787"
 )
 
 func findInstalledClaudeBinary() (string, bool) {


### PR DESCRIPTION
### What happens
`hazmat bootstrap claude` and `hazmat init` (step 17, *"Install or update Claude Code for agent user"*) abort with:
```
Claude installer checksum mismatch: expected b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830, got 005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787
```

### Root cause
`hazmat/bootstrap.go` pins the SHA-256 of `https://claude.ai/install.sh` in `claudeInstallerSHA256`. Anthropic has since updated `install.sh`, so the live script no longer matches the pinned hash and bootstrap aborts before installing Claude Code for the agent user.

The live installer hashes to exactly the `got` value:
```
$ curl -fsSL https://claude.ai/install.sh | shasum -a 256
005ec1a937f32dfbb74f9e810287bcb12cba2d5cae4c9277aa8c6364adbf1787
```
So the downloaded file is the genuine, current Anthropic installer (it fetches from `downloads.claude.ai/claude-code-releases`) — the pin is simply stale.

### Fix
Bump `claudeInstallerSHA256` to `005ec1…dbf1787`.

### Impact
Affects everyone on `v0.8.1`; `main` (`2e52a81`) still carries the old pin, so `brew upgrade` does not help.

### Verification
The only test touching this constant (`TestClaudeInstallScriptRefreshesLatestIntoAgentPrefix`) references it symbolically, so it stays green.

### Environment
- hazmat `v0.8.1` (Homebrew, `dredozubov/tap`)
- macOS (Apple Silicon)
