### PR TITLE
ci: daily drift check for the claude installer SHA-256 pin

### DIFF
--- a/.github/workflows/claude-installer-pin.yml
+++ b/.github/workflows/claude-installer-pin.yml
@@ -1,0 +1,136 @@
+name: Claude Installer Pin
+
+# Daily drift check for the SHA-256 pin of https://claude.ai/install.sh
+# (claudeInstallerSHA256 in hazmat/bootstrap.go). When upstream publishes a
+# new installer, this job opens a PR that bumps the pin and refreshes the
+# vendored copy in hazmat/testdata/claude-install.sh so the PR diff shows
+# exactly what changed in the script. It never merges anything itself:
+# a human reviewing the script diff is the point of the pin.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
+
+concurrency:
+  group: claude-installer-pin
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  drift:
+    name: Pin drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download live installer
+        run: |
+          curl -fsSL --retry 3 https://claude.ai/install.sh -o /tmp/claude-install.sh
+          test -s /tmp/claude-install.sh
+          head -c 11 /tmp/claude-install.sh | grep -q '^#!/bin/bash' || {
+            echo "Downloaded installer does not look like a bash script; refusing to propose a pin bump." >&2
+            exit 1
+          }
+
+      - name: Compare against pinned hash
+        id: compare
+        run: |
+          live=$(sha256sum /tmp/claude-install.sh | cut -d' ' -f1)
+          pinned=$(grep -oE 'claudeInstallerSHA256 = "[0-9a-f]{64}"' hazmat/bootstrap.go | grep -oE '[0-9a-f]{64}')
+          if [ -z "$pinned" ]; then
+            echo "Could not extract claudeInstallerSHA256 from hazmat/bootstrap.go" >&2
+            exit 1
+          fi
+          echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          echo "live=$live"     >> "$GITHUB_OUTPUT"
+          if [ "$live" = "$pinned" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "Pin is current ($pinned)."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "Pin is stale: pinned $pinned, live $live."
+          fi
+
+      - name: Skip if a PR for this hash already exists
+        id: existing
+        if: steps.compare.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LIVE_HASH: ${{ steps.compare.outputs.live }}
+        run: |
+          branch="ci/claude-installer-pin-${LIVE_HASH:0:12}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if gh pr list --head "$branch" --state all --json number --jq 'length' | grep -qv '^0$'; then
+            echo "open=true" >> "$GITHUB_OUTPUT"
+            echo "A PR for $branch already exists; nothing to do."
+          else
+            echo "open=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply pin bump
+        if: steps.compare.outputs.drift == 'true' && steps.existing.outputs.open == 'false'
+        env:
+          PINNED_HASH: ${{ steps.compare.outputs.pinned }}
+          LIVE_HASH: ${{ steps.compare.outputs.live }}
+        run: |
+          sed -i "s/claudeInstallerSHA256 = \"$PINNED_HASH\"/claudeInstallerSHA256 = \"$LIVE_HASH\"/" hazmat/bootstrap.go
+          cp /tmp/claude-install.sh hazmat/testdata/claude-install.sh
+          git diff --stat
+
+      - name: Verify pin and vendored script agree
+        if: steps.compare.outputs.drift == 'true' && steps.existing.outputs.open == 'false'
+        env:
+          LIVE_HASH: ${{ steps.compare.outputs.live }}
+        run: |
+          grep -q "claudeInstallerSHA256 = \"$LIVE_HASH\"" hazmat/bootstrap.go
+          echo "$LIVE_HASH  hazmat/testdata/claude-install.sh" | sha256sum -c -
+
+      - name: Open PR
+        if: steps.compare.outputs.drift == 'true' && steps.existing.outputs.open == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PINNED_HASH: ${{ steps.compare.outputs.pinned }}
+          LIVE_HASH: ${{ steps.compare.outputs.live }}
+          BRANCH: ${{ steps.existing.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add hazmat/bootstrap.go hazmat/testdata/claude-install.sh
+          git commit \
+            -m "bootstrap: bump claude installer SHA-256 pin to current install.sh" \
+            -m "Automated drift check: https://claude.ai/install.sh no longer matches the pinned hash. Review the testdata/claude-install.sh diff before merging."
+          git push origin "$BRANCH"
+          printf '%s\n' \
+            'Daily drift check found that `https://claude.ai/install.sh` no longer matches `claudeInstallerSHA256` in `hazmat/bootstrap.go`.' \
+            '' \
+            '| | SHA-256 |' \
+            '|---|---|' \
+            "| pinned | \`$PINNED_HASH\` |" \
+            "| live | \`$LIVE_HASH\` |" \
+            '' \
+            '**Review the diff of `hazmat/testdata/claude-install.sh` in this PR** — that is the full upstream script change being trusted by this bump. Do not merge if the script does anything other than fetch and verify Claude Code releases from `downloads.claude.ai`.' \
+            '' \
+            'To re-verify locally:' \
+            '```' \
+            'curl -fsSL https://claude.ai/install.sh | shasum -a 256' \
+            '```' \
+            '' \
+            'Note: PRs opened with the default `GITHUB_TOKEN` do not trigger CI. Close and reopen this PR to run the checks.' \
+            '' \
+            'Generated by `.github/workflows/claude-installer-pin.yml`.' \
+            > /tmp/pr-body.md
+          gh pr create \
+            --head "$BRANCH" \
+            --title "bootstrap: bump claude installer SHA-256 pin to current install.sh" \
+            --body-file /tmp/pr-body.md
+
+      - name: Fail run on drift
+        if: steps.compare.outputs.drift == 'true'
+        run: |
+          echo "Pin drift detected; see the PR for the proposed bump." >&2
+          exit 1

--- a/hazmat/bootstrap_pin_test.go
+++ b/hazmat/bootstrap_pin_test.go
@@ -1,0 +1,22 @@
+package hazmat
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+// The vendored copy exists so that pin bumps arrive as reviewable script
+// diffs: the claude-installer-pin workflow updates both together, and this
+// test refuses to let them drift apart.
+func TestClaudeInstallerPinMatchesVendoredScript(t *testing.T) {
+	raw, err := os.ReadFile("testdata/claude-install.sh")
+	if err != nil {
+		t.Fatalf("read vendored installer: %v", err)
+	}
+	sum := sha256.Sum256(raw)
+	if got := hex.EncodeToString(sum[:]); got != claudeInstallerSHA256 {
+		t.Fatalf("claudeInstallerSHA256 = %s but testdata/claude-install.sh hashes to %s; update both together (see .github/workflows/claude-installer-pin.yml)", claudeInstallerSHA256, got)
+	}
+}

--- a/hazmat/testdata/claude-install.sh
+++ b/hazmat/testdata/claude-install.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -e
+
+# Parse command line arguments
+TARGET="$1"  # Optional target parameter
+
+# Validate target if provided
+if [[ -n "$TARGET" ]] && [[ ! "$TARGET" =~ ^(stable|latest|[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?)$ ]]; then
+    echo "Usage: $0 [stable|latest|VERSION]" >&2
+    exit 1
+fi
+
+DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"
+DOWNLOAD_DIR="$HOME/.claude/downloads"
+
+# Check for required dependencies
+DOWNLOADER=""
+if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+else
+    echo "Either curl or wget is required but neither is installed" >&2
+    exit 1
+fi
+
+# Check if jq is available (optional)
+HAS_JQ=false
+if command -v jq >/dev/null 2>&1; then
+    HAS_JQ=true
+fi
+
+# Download function that works with both curl and wget
+download_file() {
+    local url="$1"
+    local output="$2"
+    
+    if [ "$DOWNLOADER" = "curl" ]; then
+        if [ -n "$output" ]; then
+            curl -fsSL -o "$output" "$url"
+        else
+            curl -fsSL "$url"
+        fi
+    elif [ "$DOWNLOADER" = "wget" ]; then
+        if [ -n "$output" ]; then
+            wget -q -O "$output" "$url"
+        else
+            wget -q -O - "$url"
+        fi
+    else
+        return 1
+    fi
+}
+
+# Simple JSON parser for extracting checksum when jq is not available
+get_checksum_from_manifest() {
+    local json="$1"
+    local platform="$2"
+    
+    # Normalize JSON to single line and extract checksum
+    json=$(echo "$json" | tr -d '\n\r\t' | sed 's/ \+/ /g')
+    
+    # Extract checksum for platform using bash regex
+    if [[ $json =~ \"$platform\"[^}]*\"checksum\"[[:space:]]*:[[:space:]]*\"([a-f0-9]{64})\" ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    
+    return 1
+}
+
+# Detect platform
+case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux) os="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "Windows is not supported by this script. See https://code.claude.com/docs for installation options." >&2; exit 1 ;;
+    *) echo "Unsupported operating system: $(uname -s). See https://code.claude.com/docs for supported platforms." >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Detect Rosetta 2 on macOS: if the shell is running as x64 under Rosetta on an ARM Mac,
+# download the native arm64 binary instead of the x64 one
+if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
+    if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]; then
+        arch="arm64"
+    fi
+fi
+
+# Check for musl on Linux and adjust platform accordingly
+if [ "$os" = "linux" ]; then
+    if [ -f /lib/libc.musl-x86_64.so.1 ] || [ -f /lib/libc.musl-aarch64.so.1 ] || ldd /bin/ls 2>&1 | grep -q musl; then
+        platform="linux-${arch}-musl"
+    else
+        platform="linux-${arch}"
+    fi
+else
+    platform="${os}-${arch}"
+fi
+mkdir -p "$DOWNLOAD_DIR"
+
+# Always download latest version (which has the most up-to-date installer)
+version=$(download_file "$DOWNLOAD_BASE_URL/latest")
+
+# Reject non-version content (e.g. an HTML error page) before it reaches the manifest URL
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Failed to get a valid version from downloads.claude.ai (got unexpected content)." >&2
+    echo "This can happen if the download service is unreachable or not available in your region - see https://www.anthropic.com/supported-countries" >&2
+    exit 1
+fi
+
+# Download manifest and extract checksum
+manifest_json=$(download_file "$DOWNLOAD_BASE_URL/$version/manifest.json")
+
+# Use jq if available, otherwise fall back to pure bash parsing
+if [ "$HAS_JQ" = true ]; then
+    checksum=$(echo "$manifest_json" | jq -r ".platforms[\"$platform\"].checksum // empty")
+else
+    checksum=$(get_checksum_from_manifest "$manifest_json" "$platform")
+fi
+
+# Validate checksum format (SHA256 = 64 hex characters)
+if [ -z "$checksum" ] || [[ ! "$checksum" =~ ^[a-f0-9]{64}$ ]]; then
+    echo "Platform $platform not found in manifest" >&2
+    exit 1
+fi
+
+# Download and verify
+binary_path="$DOWNLOAD_DIR/claude-$version-$platform"
+if ! download_file "$DOWNLOAD_BASE_URL/$version/$platform/claude" "$binary_path"; then
+    echo "Download failed" >&2
+    rm -f "$binary_path"
+    exit 1
+fi
+
+# Pick the right checksum tool
+if [ "$os" = "darwin" ]; then
+    actual=$(shasum -a 256 "$binary_path" | cut -d' ' -f1)
+else
+    actual=$(sha256sum "$binary_path" | cut -d' ' -f1)
+fi
+
+if [ "$actual" != "$checksum" ]; then
+    echo "Checksum verification failed" >&2
+    rm -f "$binary_path"
+    exit 1
+fi
+
+chmod +x "$binary_path"
+
+# Run claude install to set up launcher and shell integration
+echo "Setting up Claude Code..."
+"$binary_path" install ${TARGET:+"$TARGET"}
+
+# Clean up downloaded file
+rm -f "$binary_path"
+
+echo ""
+echo "✅ Installation complete!"
+echo ""


### PR DESCRIPTION
## What

Follow-up to #11, so a stale `claudeInstallerSHA256` never silently breaks `hazmat init`/`hazmat bootstrap claude` again.

- **`.github/workflows/claude-installer-pin.yml`** — daily (07:00 UTC) + manual dispatch. Downloads `https://claude.ai/install.sh`, compares its SHA-256 to the pin in `hazmat/bootstrap.go`. On drift it opens a PR bumping the pin; it never merges anything itself.
- **`hazmat/testdata/claude-install.sh`** — vendored copy of the currently-pinned installer. The auto-PR refreshes it together with the pin, so the PR diff shows exactly what changed in the upstream script instead of an opaque hash swap.
- **`hazmat/bootstrap_pin_test.go`** — unit test asserting sha256(vendored copy) == `claudeInstallerSHA256`, so the two can never drift apart.

## Design notes

- **No auto-merge.** Auto-merging a pin bump would reduce the pin to TOFU. The job's output is a reviewable PR whose script diff is the audit surface.
- **No third-party actions** beyond `actions/checkout` — keeps the workflow itself out of the supply-chain blast radius.
- Scheduled runs stay red while drift is unresolved, so you get notified daily until the bump PR is merged. Duplicate PRs are suppressed by hash-derived branch names.
- The Codex installer needs no equivalent: its hash is fetched per-release from GitHub digests, not statically pinned.

## Setup required

Repo setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** must be enabled, or `gh pr create` in the job will fail.