### PR TITLE
ci: fix release and cross-compile builds after cmd/hazmat split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,11 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
-        run: go build -trimpath -o hazmat-${{ matrix.goos }}-${{ matrix.goarch }} .
+        # ./cmd/hazmat, not "." — building the library package would silently
+        # produce an ar archive instead of the CLI binary.
+        run: |
+          go build -trimpath -o hazmat-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/hazmat
+          file hazmat-${{ matrix.goos }}-${{ matrix.goarch }} | grep -q 'Mach-O.*executable'
 
       - name: Build hazmat-launch (CGO required for sandbox_init)
         working-directory: hazmat
@@ -183,7 +187,9 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '1'
           CC: clang -arch ${{ matrix.cc_arch }}
-        run: go build -trimpath -o hazmat-launch-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/hazmat-launch
+        run: |
+          go build -trimpath -o hazmat-launch-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/hazmat-launch
+          file hazmat-launch-${{ matrix.goos }}-${{ matrix.goarch }} | grep -q 'Mach-O.*executable'
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,11 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
           VERSION: ${{ github.ref_name }}
-        run: go build -trimpath -ldflags "-X main.version=${VERSION}" -o hazmat .
+        # ./cmd/hazmat + hazmat.version must match the root Makefile; building
+        # "." here silently produces an ar archive since the cmd/hazmat split.
+        run: |
+          go build -trimpath -ldflags "-X hazmat.version=${VERSION}" -o hazmat ./cmd/hazmat
+          file hazmat | grep -q 'Mach-O.*executable'
 
       - name: Build hazmat-launch (CGO required for sandbox_init)
         working-directory: hazmat
@@ -47,7 +51,9 @@ jobs:
           CGO_ENABLED: '1'
           CC: clang -arch ${{ matrix.cc_arch }}
           VERSION: ${{ github.ref_name }}
-        run: go build -trimpath -ldflags "-X main.version=${VERSION}" -o hazmat-launch ./cmd/hazmat-launch
+        run: |
+          go build -trimpath -ldflags "-X hazmat.version=${VERSION}" -o hazmat-launch ./cmd/hazmat-launch
+          file hazmat-launch | grep -q 'Mach-O.*executable'
 
       - name: Package
         working-directory: hazmat

--- a/hazmat/exec.go
+++ b/hazmat/exec.go
@@ -2,6 +2,7 @@ package hazmat
 
 import (
 	"os/exec"
+	"strings"
 
 	"hazmat/internal/diagnostics"
 	"hazmat/internal/hostexec"
@@ -62,27 +63,33 @@ func sudoAppendFile(path, content string) error {
 
 // asAgentQuiet runs args as the agent user via Hazmat's helper-backed
 // maintenance path, discarding stdout/stderr. Returns exit code only.
+// Built through the newAgentCommand seam so tests can interpose every
+// agent exec, not just direct newAgentCommand callers.
 func asAgentQuiet(args ...string) error {
-	return hostexec.AsAgentQuiet(hostExecEnv(), args...)
+	cmd := newAgentCommand(args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
 }
 
 // asAgentOutput runs args as the agent user and returns stdout only.
 // This prevents stderr from failed reads like "cat missing-file" from being
 // mistaken for file content by callers that ignore the returned error.
 func asAgentOutput(args ...string) (string, error) {
-	return hostexec.AsAgentOutput(hostExecEnv(), args...)
+	return hostexec.CommandStdoutCmd(newAgentCommand(args...))
 }
 
 // asAgentCombinedOutput runs args as the agent user and returns combined
 // stdout/stderr. Callers should surface stderr intentionally.
 func asAgentCombinedOutput(args ...string) (string, error) {
-	return hostexec.AsAgentCombinedOutput(hostExecEnv(), args...)
+	out, err := newAgentCommand(args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
 }
 
 // asAgentShellQuiet runs a bash command string as the agent user.
 // Use only with hardcoded scripts — never interpolate user input.
 func asAgentShellQuiet(script string) error {
-	return hostexec.AsAgentShellQuiet(hostExecEnv(), script)
+	return asAgentQuiet("bash", "-c", script)
 }
 
 func agentTCPConnect(selfPath, host, port string) bool {

--- a/hazmat/harness_smoke_hermetic_test.go
+++ b/hazmat/harness_smoke_hermetic_test.go
@@ -1,6 +1,6 @@
 //go:build hazmat_smoke_fixture
 
-package main
+package hazmat
 
 import (
 	"bytes"


### PR DESCRIPTION
## What

Release-blocking fixes found while preparing v0.9.0. Since 5ce4831 ("Split CLI entrypoint into cmd hazmat") the `hazmat/` directory is `package hazmat` and the CLI entrypoint is `./cmd/hazmat`, but:

- **`release.yml`** still ran `go build -o hazmat .` — with a non-main package this *silently produces an ar archive*, so the next tagged release would have shipped a non-executable `hazmat` in the tarballs and the Homebrew tap. It also still set `-X main.version`; the version var is `hazmat.version` (as the root Makefile already does).
- **`ci.yml` cross-compile job** had the same `.` build — green checks, garbage output, so CI never caught it.
- **`harness_smoke_hermetic_test.go`** (behind `hazmat_smoke_fixture`) still said `package main`, breaking `scripts/pre-release-local.sh`'s e2e smoke with a package mismatch.

With the package fixed, the smoke surfaced a second regression:

- **d2f9b65** ("Move host execution primitives to hostexec") pointed the `asAgent*` wrappers straight at `internal/hostexec`, bypassing the `newAgentCommand` test seam. Production behavior is identical (the seam's default is the same hostexec path), but the hermetic smoke's forbidden-sudo stub no longer intercepted agent execs, so `prepareAgentTempRuntime` invoked the stub and failed with exit 97. The wrappers are now built from `newAgentCommand` again.

## Hardening

Both workflows now assert `file <output> | grep -q 'Mach-O.*executable'` after building, so a repeat fails loudly instead of uploading an archive.

## Verification

- `go build -trimpath -ldflags "-X hazmat.version=v0.9.0-test" -o ... ./cmd/hazmat` → Mach-O executable with the version string embedded (checked via `strings`).
- `go test -tags hazmat_smoke_fixture -run TestHermeticHarnessSmoke .` → ok (was failing at setup, then at the sudo stub).
- Full `go test ./...` green.
- Full `scripts/pre-release-local.sh` re-run in progress.