### PR TITLE
ci: bump actions/checkout@v4 to v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Secret patterns
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Reject provider-shaped credential patterns
         run: bash scripts/check-secret-patterns.sh
@@ -42,7 +42,7 @@ jobs:
     env:
       GITLEAKS_VERSION: "8.30.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
     name: Lint
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -75,7 +75,7 @@ jobs:
     name: Test & vet
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -98,7 +98,7 @@ jobs:
     name: Linux compile-only
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -112,7 +112,7 @@ jobs:
     name: Test entrypoint guards
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify non-destructive test-entrypoint guards
         run: bash scripts/test-entrypoint-guards.sh
@@ -124,7 +124,7 @@ jobs:
     name: Repo matrix contract
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -161,7 +161,7 @@ jobs:
             goarch: amd64
             cc_arch: x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -203,7 +203,7 @@ jobs:
     name: TLA+ proof hygiene
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check TLA+ proof ownership ledger
         working-directory: tla
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tla-proof-hygiene]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-java@v4
         with:
@@ -283,7 +283,7 @@ jobs:
     runs-on: macos-14
     needs: [go-test, linux-compile, go-build, test-entrypoint-guards, repo-matrix-contract]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -300,7 +300,7 @@ jobs:
     env:
       HOMEBREW_NO_AUTO_UPDATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -344,7 +344,7 @@ jobs:
     env:
       HOMEBREW_NO_AUTO_UPDATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/claude-installer-pin.yml
+++ b/.github/workflows/claude-installer-pin.yml
@@ -25,7 +25,7 @@ jobs:
     name: Pin drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download live installer
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             goarch: amd64
             cc_arch: x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -74,7 +74,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:
@@ -101,7 +101,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/stack-matrix-drift.yml
+++ b/.github/workflows/stack-matrix-drift.yml
@@ -21,7 +21,7 @@ jobs:
     name: Drift check
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
GitHub forces JavaScript actions onto Node 24 starting **2026-06-16** and removes Node 20 from runners on **2026-09-16**. `actions/checkout@v4` triggered deprecation annotations on recent runs (e.g. run 27274237349).

Bumps all 18 `actions/checkout@v4` usages to `@v5` across:
- `ci.yml` (13)
- `claude-installer-pin.yml` (1)
- `release.yml` (3)
- `stack-matrix-drift.yml` (1)

No other changes. Tracked as OPS-g3jd.